### PR TITLE
Clarify placeholder handling for missing tracks

### DIFF
--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -300,9 +300,9 @@ class ProfileCog(commands.Cog):
     async def addwish_epic(self, interaction: discord.Interaction, track: str, note: Optional[str] = None) -> None:
         user_id = str(interaction.user.id)
         await self.ensure_user(user_id)
-        # Ensure track exists in DB; if not, create a dummy entry from Spotify?
-        # Here we assume it exists if it's selected via autocomplete. If not,
-        # upsert as unknown. We don't want to call Spotify search implicitly.
+        # Ensure track exists in DB. If it's missing, insert a placeholder row
+        # with "Unbekannter Titel"/"Unbekannter Künstler" instead of calling
+        # the Spotify API.
         exists = await db.fetch_one(
             "SELECT 1 FROM tracks WHERE track_id=?",
             (track,),


### PR DESCRIPTION
## Summary
- clarify behavior when adding unknown tracks to wishlist, noting placeholder "Unbekannter Titel/Künstler" is created without Spotify API

## Testing
- `python -m pytest`
- `python -m py_compile cogs/profile.py`


------
https://chatgpt.com/codex/tasks/task_e_6897d8392dc4832b9dfef08579790a2b