### PR TITLE
Add tests for chunked utility function

### DIFF
--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.util import chunked
+
+
+def test_chunked_splits_sequence_into_expected_sublists():
+    sequence = [1, 2, 3, 4, 5]
+    result = list(chunked(sequence, 2))
+    assert result == [[1, 2], [3, 4], [5]]
+
+
+@pytest.mark.parametrize("size", [0, -1])
+def test_chunked_raises_value_error_for_non_positive_size(size):
+    with pytest.raises(ValueError):
+        list(chunked([1, 2, 3], size))


### PR DESCRIPTION
## Summary
- add tests for chunked helper covering normal operation and error for non-positive size

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897d83862d8832b8d5e2d1a1f493951