### PR TITLE
feat: add Soundmap username management

### DIFF
--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -3,6 +3,7 @@
 -- Users table to persist per-user settings.
 CREATE TABLE IF NOT EXISTS users (
   user_id TEXT PRIMARY KEY,
+  soundmap_username TEXT,
   epic_sort_mode TEXT NOT NULL DEFAULT 'added',
   created_at TEXT DEFAULT CURRENT_TIMESTAMP
 );

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -87,3 +87,54 @@ def test_addepic_inserts_epic(monkeypatch):
     assert dummy_execute.called
     assert "✅ Epic hinzugefügt" in interaction.response.message
     asyncio.run(bot.close())
+
+
+def test_set_sm_username(monkeypatch):
+    intents = discord.Intents.none()
+    bot = commands.Bot(command_prefix="!", intents=intents)
+    cog = ProfileCog(bot)
+
+    async def dummy_execute(query, params=()):
+        dummy_execute.data.append((query, params))
+
+    dummy_execute.data = []
+
+    async def dummy_ensure_user(self, uid):
+        pass
+
+    monkeypatch.setattr(db, "execute", dummy_execute)
+    monkeypatch.setattr(ProfileCog, "ensure_user", dummy_ensure_user)
+
+    interaction = DummyInteraction()
+    asyncio.run(ProfileCog.set_sm_username.callback(cog, interaction, "Foo"))
+
+    assert dummy_execute.data[0][1] == ("Foo", "1")
+    assert "Soundmap-Username gesetzt" in interaction.response.message
+    asyncio.run(bot.close())
+
+
+def test_build_profile_embed_includes_username(monkeypatch):
+    intents = discord.Intents.none()
+    bot = commands.Bot(command_prefix="!", intents=intents)
+    cog = ProfileCog(bot)
+
+    member = types.SimpleNamespace(id=1, display_name="Tester")
+
+    async def dummy_fetch_one(query, params=()):
+        return {"epic_sort_mode": "added", "soundmap_username": "Foo"}
+
+    async def dummy_fetch_all(query, params=()):
+        return []
+
+    async def dummy_ensure_user(self, uid):
+        pass
+
+    monkeypatch.setattr(db, "fetch_one", dummy_fetch_one)
+    monkeypatch.setattr(db, "fetch_all", dummy_fetch_all)
+    monkeypatch.setattr(ProfileCog, "ensure_user", dummy_ensure_user)
+
+    embed = asyncio.run(cog.build_profile_embed(member))
+
+    assert embed.fields[0].name == "👤 Soundmap-Name"
+    assert embed.fields[0].value == "Foo"
+    asyncio.run(bot.close())


### PR DESCRIPTION
## Summary
- store Soundmap usernames in `users` table
- capture username via modal on profile command
- allow updating username with `/set_sm_username`
- show username at top of profile embed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897edb1a2bc832bae4ee88a60bbe206