### PR TITLE
feat: add username management

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -46,6 +46,13 @@ async def init_db() -> None:
     # executescript automatically wraps statements in a single transaction
     await db.executescript(sql)
     await db.commit()
+    # Ensure the new username column exists for the users table
+    try:
+        await db.execute("ALTER TABLE users ADD COLUMN username TEXT")
+        await db.commit()
+    except Exception:
+        # Column already exists or cannot be added; ignore
+        pass
 
 
 async def fetch_one(query: str, params: tuple | list = ()) -> aiosqlite.Row | None:

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -3,6 +3,7 @@
 -- Users table to persist per-user settings.
 CREATE TABLE IF NOT EXISTS users (
   user_id TEXT PRIMARY KEY,
+  username TEXT,
   epic_sort_mode TEXT NOT NULL DEFAULT 'added',
   created_at TEXT DEFAULT CURRENT_TIMESTAMP
 );

--- a/tests/test_username.py
+++ b/tests/test_username.py
@@ -1,0 +1,89 @@
+import types
+from pathlib import Path
+import sys
+import os
+import asyncio
+import discord
+from discord.ext import commands
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("DISCORD_TOKEN", "test-token")
+os.environ.setdefault("SPOTIFY_CLIENT_ID", "cid")
+os.environ.setdefault("SPOTIFY_CLIENT_SECRET", "csecret")
+
+from cogs.profile import ProfileCog, UsernameModal
+from core import db
+
+
+class DummyResponse:
+    def __init__(self):
+        self.message = None
+        self.kwargs = None
+
+    async def send_message(self, message=None, **kwargs):
+        self.message = message
+        self.kwargs = kwargs
+
+
+class DummyInteraction:
+    def __init__(self, user_id=1):
+        self.user = types.SimpleNamespace(id=user_id, display_name=f"User{user_id}")
+        self.response = DummyResponse()
+
+
+def test_username_modal_updates_db(monkeypatch):
+    intents = discord.Intents.none()
+    bot = commands.Bot(command_prefix="!", intents=intents)
+    cog = ProfileCog(bot)
+
+    executed = {}
+
+    async def dummy_execute(query, params=()):
+        executed["query"] = query
+        executed["params"] = params
+
+    async def dummy_ensure_user(self, uid):
+        pass
+
+    monkeypatch.setattr(db, "execute", dummy_execute)
+    monkeypatch.setattr(ProfileCog, "ensure_user", dummy_ensure_user)
+
+    interaction = DummyInteraction()
+
+    async def run_modal():
+        modal = UsernameModal(cog)
+        modal.username._value = "Player1"
+        await modal.on_submit(interaction)
+
+    asyncio.run(run_modal())
+
+    assert executed["params"] == ("Player1", "1")
+    assert "Username gesetzt" in interaction.response.message
+    asyncio.run(bot.close())
+
+
+def test_profile_shows_username(monkeypatch):
+    intents = discord.Intents.none()
+    bot = commands.Bot(command_prefix="!", intents=intents)
+    cog = ProfileCog(bot)
+
+    async def dummy_fetch_one(query, params=()):
+        return {"username": "PlayerX", "epic_sort_mode": "added"}
+
+    async def dummy_fetch_all(query, params=()):
+        return []
+
+    async def dummy_ensure_user(self, uid):
+        pass
+
+    monkeypatch.setattr(db, "fetch_one", dummy_fetch_one)
+    monkeypatch.setattr(db, "fetch_all", dummy_fetch_all)
+    monkeypatch.setattr(ProfileCog, "ensure_user", dummy_ensure_user)
+
+    interaction = DummyInteraction()
+    asyncio.run(ProfileCog.profile.callback(cog, interaction, None))
+    embed = interaction.response.kwargs["embed"]
+    assert embed.fields[0].name == "👤 Username"
+    assert embed.fields[0].value == "PlayerX"
+    asyncio.run(bot.close())
+


### PR DESCRIPTION
## Summary
- allow users to set their Soundmap ingame name via `/username` modal
- display stored usernames at the top of `/profile`
- extend database schema and add tests for username support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897f21c3b98832baf2a0ec1bba321d9