### PR TITLE
Rename username label in profile

### DIFF
--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -538,7 +538,7 @@ class ProfileCog(commands.Cog):
             color=discord.Color.purple(),
         )
         if username:
-            embed.insert_field_at(0, name="👤 Username", value=username, inline=False)
+            embed.insert_field_at(0, name="👤 SM-Username", value=username, inline=False)
         # Epics list
         if epics:
             epic_lines: list[str] = []

--- a/tests/test_username.py
+++ b/tests/test_username.py
@@ -78,7 +78,7 @@ def test_profile_shows_username(monkeypatch):
     interaction = DummyInteraction()
     asyncio.run(ProfileCog.profile.callback(cog, interaction, None))
     embed = interaction.response.kwargs["embed"]
-    assert embed.fields[0].name == "👤 Username"
+    assert embed.fields[0].name == "👤 SM-Username"
     assert embed.fields[0].value == "PlayerX"
     asyncio.run(bot.close())
 


### PR DESCRIPTION
## Summary
- display user profile name field as **SM-Username** instead of **Username**
- adjust tests for new label

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689873a2a7e4832bbfe171bff70218ed