### PR TITLE
Translate profile view to English

### DIFF
--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -165,11 +165,11 @@ class ProfileCog(commands.Cog):
             results = await spotify.search_artists(term, limit=10) if term else []
         except Exception:
             results = []
-        # Wir geben den Namen als value zurück; DB-Insert kümmert sich um das Anlegen
+        # Return the name as the value; the DB insert handles creation
         return [app_commands.Choice(name=a["name"][:100], value=a["name"]) for a in results][:25]
 
-    @app_commands.command(name="username", description="Setze deinen Soundmap-Ingame-Username")
-    @app_commands.describe(name="Dein neuer Ingame-Username")
+    @app_commands.command(name="username", description="Set your Soundmap in-game username")
+    @app_commands.describe(name="Your new in-game username")
     async def username(self, interaction: discord.Interaction, name: str) -> None:
         """Set or update the ingame Soundmap username directly."""
         user_id = str(interaction.user.id)
@@ -179,15 +179,15 @@ class ProfileCog(commands.Cog):
             "UPDATE users SET username=? WHERE user_id=?", (name, user_id)
         )
         await interaction.response.send_message(
-            f"✅ Username gesetzt: **{name}**", ephemeral=True
+            f"✅ Username set: **{name}**", ephemeral=True
         )
 
     # Command: add Epic via Spotify search with autocomplete
-    @app_commands.command(name="addepic", description="Füge ein Epic aus Spotify hinzu")
+    @app_commands.command(name="addepic", description="Add an Epic from Spotify")
     @app_commands.rename(track="song", epic_number="number")
     @app_commands.describe(
-        track="Der Song (über Autocomplete auswählbar)",
-        epic_number="Die Seriennummer des Epics",
+        track="The song (selectable via autocomplete)",
+        epic_number="The serial number of the Epic",
     )
     @app_commands.autocomplete(track=autocomplete_spotify_tracks)
     async def addepic(
@@ -200,12 +200,12 @@ class ProfileCog(commands.Cog):
             t = None
         if not t:
             await interaction.response.send_message(
-                "Song nicht gefunden.", ephemeral=True
+                "Song not found.", ephemeral=True
             )
             return
         if epic_number <= 0:
             await interaction.response.send_message(
-                "Epic-Nummer muss > 0 sein.", ephemeral=True
+                "Epic number must be > 0.", ephemeral=True
             )
             return
         user_id = str(interaction.user.id)
@@ -221,7 +221,7 @@ class ProfileCog(commands.Cog):
         )
         if exists:
             await interaction.response.send_message(
-                "Du besitzt dieses Epic bereits.", ephemeral=True
+                "You already own this Epic.", ephemeral=True
             )
             return
         next_pos = await self.get_next_position(user_id)
@@ -233,14 +233,14 @@ class ProfileCog(commands.Cog):
             (user_id, t["track_id"], epic_number, next_pos),
         )
         await interaction.response.send_message(
-            f"✅ Epic hinzugefügt: **{t['artist_name']} – {t['title']}** (# {epic_number})",
+            f"✅ Epic added: **{t['artist_name']} – {t['title']}** (# {epic_number})",
             ephemeral=True,
         )
 
     # Command: remove an Epic
-    @app_commands.command(name="delepic", description="Entferne ein Epic aus deiner Sammlung")
+    @app_commands.command(name="delepic", description="Remove an Epic from your collection")
     @app_commands.rename(track="song", epic_number="number")
-    @app_commands.describe(track="Der Song (über Autocomplete auswählbar)", epic_number="Die Seriennummer des Epics")
+    @app_commands.describe(track="The song (selectable via autocomplete)", epic_number="The serial number of the Epic")
     @app_commands.autocomplete(track=autocomplete_tracks)
     async def delepic(self, interaction: discord.Interaction, track: str, epic_number: int) -> None:
         user_id = str(interaction.user.id)
@@ -251,7 +251,7 @@ class ProfileCog(commands.Cog):
         )
         if not row:
             await interaction.response.send_message(
-                "Du besitzt dieses Epic nicht.",
+                "You don't own this Epic.",
                 ephemeral=True,
             )
             return
@@ -272,14 +272,14 @@ class ProfileCog(commands.Cog):
                 (user_id, pos),
             )
         await interaction.response.send_message(
-            "✅ Epic entfernt.",
+            "✅ Epic removed.",
             ephemeral=True,
         )
 
     # Command: add a song to the wishlist via Spotify search
-    @app_commands.command(name="addwish", description="Füge einen Song zu deiner Wunschliste hinzu")
+    @app_commands.command(name="addwish", description="Add a song to your wishlist")
     @app_commands.rename(track="song")
-    @app_commands.describe(track="Der Song (über Autocomplete auswählbar)", note="Optionale Notiz")
+    @app_commands.describe(track="The song (selectable via autocomplete)", note="Optional note")
     @app_commands.autocomplete(track=autocomplete_spotify_tracks)
     async def addwish(self, interaction: discord.Interaction, track: str, note: Optional[str] = None) -> None:
         user_id = str(interaction.user.id)
@@ -290,7 +290,7 @@ class ProfileCog(commands.Cog):
         except Exception:
             t = None
         if not t:
-            await interaction.response.send_message("Song nicht gefunden.", ephemeral=True)
+            await interaction.response.send_message("Song not found.", ephemeral=True)
             return
         await spotify.upsert_track(t["track_id"], t["title"], t["artist_name"], t["url"])
         # Insert or update wishlist note
@@ -303,17 +303,17 @@ class ProfileCog(commands.Cog):
                 "UPDATE user_wishlist_epics SET note=? WHERE user_id=? AND track_id=?",
                 (note, user_id, t["track_id"]),
             )
-            msg = "Die Notiz deiner Wunschliste wurde aktualisiert."
+            msg = "Wishlist note updated."
         else:
             await db.execute(
                 "INSERT INTO user_wishlist_epics(user_id, track_id, note) VALUES(?,?,?)",
                 (user_id, t["track_id"], note),
             )
-            msg = "✅ Zur Wunschliste hinzugefügt."
+            msg = "✅ Added to wishlist."
         await interaction.response.send_message(msg, ephemeral=True)
 
     # Command: remove from wishlist
-    @app_commands.command(name="delwish", description="Entferne einen Song aus deiner Wunschliste")
+    @app_commands.command(name="delwish", description="Remove a song from your wishlist")
     @app_commands.rename(track="song")
     @app_commands.autocomplete(track=autocomplete_tracks)
     async def delwish(self, interaction: discord.Interaction, track: str) -> None:
@@ -323,16 +323,16 @@ class ProfileCog(commands.Cog):
             (user_id, track),
         )
         if not row:
-            await interaction.response.send_message("Dieser Song ist nicht auf deiner Wunschliste.", ephemeral=True)
+            await interaction.response.send_message("This song is not on your wishlist.", ephemeral=True)
             return
         await db.execute(
             "DELETE FROM user_wishlist_epics WHERE user_id=? AND track_id=?",
             (user_id, track),
         )
-        await interaction.response.send_message("✅ Von der Wunschliste entfernt.", ephemeral=True)
+        await interaction.response.send_message("✅ Removed from wishlist.", ephemeral=True)
 
     # ---------- UPDATED: add favourite artist (Spotify validation) ----------
-    @app_commands.command(name="addartist", description="Füge einen Lieblingskünstler hinzu")
+    @app_commands.command(name="addartist", description="Add a favorite artist")
     @app_commands.autocomplete(artist=autocomplete_artists)
     async def addartist(self, interaction: discord.Interaction, artist: str) -> None:
         user_id = str(interaction.user.id)
@@ -341,7 +341,7 @@ class ProfileCog(commands.Cog):
         # Spotify-Validierung & Kanonisierung
         sp = await spotify.get_canonical_artist(artist)
         if not sp:
-            await interaction.response.send_message("Künstler nicht bei Spotify gefunden.", ephemeral=True)
+            await interaction.response.send_message("Artist not found on Spotify.", ephemeral=True)
             return
         canonical_name = sp["name"]
 
@@ -352,19 +352,19 @@ class ProfileCog(commands.Cog):
         )
         row = await db.fetch_one("SELECT artist_id FROM artists WHERE name=?", (canonical_name,))
         if not row:
-            await interaction.response.send_message("Interner Fehler beim Speichern des Künstlers.", ephemeral=True)
+            await interaction.response.send_message("Internal error saving artist.", ephemeral=True)
             return
         artist_id_int = row["artist_id"]
 
-        # Lieblingskünstler setzen
+        # Set favorite artist
         await db.execute(
             "INSERT INTO user_fav_artists(user_id, artist_id) VALUES(?,?) ON CONFLICT(user_id, artist_id) DO NOTHING",
             (user_id, artist_id_int),
         )
-        await interaction.response.send_message(f"✅ Lieblingskünstler hinzugefügt: **{canonical_name}**.", ephemeral=True)
+        await interaction.response.send_message(f"✅ Favorite artist added: **{canonical_name}**.", ephemeral=True)
 
     # ---------- NEW: remove favourite artist ----------
-    @app_commands.command(name="delartist", description="Entferne einen Lieblingskünstler")
+    @app_commands.command(name="delartist", description="Remove a favorite artist")
     @app_commands.autocomplete(artist=autocomplete_artists)
     async def delartist(self, interaction: discord.Interaction, artist: str) -> None:
         user_id = str(interaction.user.id)
@@ -373,14 +373,14 @@ class ProfileCog(commands.Cog):
         # Spotify-Validierung & Kanonisierung
         sp = await spotify.get_canonical_artist(artist)
         if not sp:
-            await interaction.response.send_message("Künstler nicht bei Spotify gefunden.", ephemeral=True)
+            await interaction.response.send_message("Artist not found on Spotify.", ephemeral=True)
             return
         canonical_name = sp["name"]
 
         # Artist-ID nachschlagen
         row = await db.fetch_one("SELECT artist_id FROM artists WHERE name=?", (canonical_name,))
         if not row:
-            await interaction.response.send_message("Dieser Künstler ist nicht in deiner Liste.", ephemeral=True)
+            await interaction.response.send_message("This artist is not in your list.", ephemeral=True)
             return
         artist_id_int = row["artist_id"]
 
@@ -389,7 +389,7 @@ class ProfileCog(commands.Cog):
             (user_id, artist_id_int),
         )
         if not fav_row:
-            await interaction.response.send_message("Dieser Künstler ist nicht in deiner Liste.", ephemeral=True)
+            await interaction.response.send_message("This artist is not in your list.", ephemeral=True)
             return
 
         await db.execute(
@@ -397,14 +397,14 @@ class ProfileCog(commands.Cog):
             (user_id, artist_id_int),
         )
         await interaction.response.send_message(
-            f"✅ Lieblingskünstler entfernt: **{canonical_name}**.", ephemeral=True
+            f"✅ Favorite artist removed: **{canonical_name}**.", ephemeral=True
         )
 
     # ---------- UPDATED: set badge with Spotify validation ----------
-    @app_commands.command(name="setbadge", description="Setze dein Badge für einen Lieblingskünstler")
+    @app_commands.command(name="setbadge", description="Set your badge for a favorite artist")
     @app_commands.autocomplete(artist=autocomplete_artists)
     @app_commands.choices(badge=[app_commands.Choice(name=b, value=b) for b in BADGES])
-    @app_commands.describe(badge="Welches Badge du besitzt")
+    @app_commands.describe(badge="Which badge you have")
     async def setbadge(self, interaction: discord.Interaction, artist: str, badge: app_commands.Choice[str]) -> None:
         user_id = str(interaction.user.id)
         await self.ensure_user(user_id)
@@ -412,11 +412,11 @@ class ProfileCog(commands.Cog):
         # Spotify-Validierung & Kanonisierung
         sp = await spotify.get_canonical_artist(artist)
         if not sp:
-            await interaction.response.send_message("Künstler nicht bei Spotify gefunden.", ephemeral=True)
+            await interaction.response.send_message("Artist not found on Spotify.", ephemeral=True)
             return
         canonical_name = sp["name"]
 
-        # Sicherstellen, dass der Künstler in 'artists' existiert
+        # Ensure the artist exists in 'artists'
         await db.execute(
             "INSERT INTO artists(name) VALUES(?) ON CONFLICT(name) DO NOTHING",
             (canonical_name,),
@@ -433,14 +433,14 @@ class ProfileCog(commands.Cog):
             """,
             (user_id, artist_id_int, badge.value),
         )
-        await interaction.response.send_message(f"✅ Badge **{badge.value}** gesetzt für **{canonical_name}**.", ephemeral=True)
+        await interaction.response.send_message(f"✅ Badge **{badge.value}** set for **{canonical_name}**.", ephemeral=True)
 
     # Command: set epic sort mode
-    @app_commands.command(name="set_epic_sort", description="Wähle die Sortierung deiner Epics im Profil")
+    @app_commands.command(name="set_epic_sort", description="Choose how your Epics are sorted in the profile")
     @app_commands.choices(mode=[
-        app_commands.Choice(name="Hinzufüge-Reihenfolge", value="added"),
-        app_commands.Choice(name="Nach Artist", value="artist"),
-        app_commands.Choice(name="Manuell", value="manual"),
+        app_commands.Choice(name="Added order", value="added"),
+        app_commands.Choice(name="By artist", value="artist"),
+        app_commands.Choice(name="Manual", value="manual"),
     ])
     async def set_epic_sort(self, interaction: discord.Interaction, mode: app_commands.Choice[str]) -> None:
         user_id = str(interaction.user.id)
@@ -450,14 +450,14 @@ class ProfileCog(commands.Cog):
             (user_id, mode.value),
         )
         await interaction.response.send_message(
-            f"✅ Sortiermodus auf **{mode.name}** gesetzt.",
+            f"✅ Sort mode set to **{mode.name}**.",
             ephemeral=True,
         )
 
     # Command: move epic manually
-    @app_commands.command(name="move_epic", description="Verschiebe ein Epic an eine bestimmte Position")
+    @app_commands.command(name="move_epic", description="Move an Epic to a specific position")
     @app_commands.autocomplete(track=autocomplete_tracks)
-    @app_commands.describe(epic_number="Die Seriennummer des Epics", to="Die Zielposition (1-basiert)")
+    @app_commands.describe(epic_number="The epic's serial number", to="The target position (1-based)")
     async def move_epic(self, interaction: discord.Interaction, track: str, epic_number: int, to: int) -> None:
         user_id = str(interaction.user.id)
         try:
@@ -465,10 +465,10 @@ class ProfileCog(commands.Cog):
         except ValueError as e:
             await interaction.response.send_message(str(e), ephemeral=True)
             return
-        await interaction.response.send_message("✅ Epic verschoben.", ephemeral=True)
+        await interaction.response.send_message("✅ Epic moved.", ephemeral=True)
 
     # Command: show profile
-    @app_commands.command(name="profile", description="Zeige dein Soundmap-Profil an")
+    @app_commands.command(name="profile", description="Show your Soundmap profile")
     async def profile(self, interaction: discord.Interaction, user: Optional[discord.Member] = None) -> None:
         member = user or interaction.user
         user_id = str(member.id)
@@ -538,7 +538,7 @@ class ProfileCog(commands.Cog):
         )
         # Build embed
         embed = discord.Embed(
-            title=f"🎵 Soundmap Profil von {member.display_name}",
+            title=f"🎵 {member.display_name}'s Collection",
             color=discord.Color.purple(),
         )
         if username:
@@ -551,10 +551,10 @@ class ProfileCog(commands.Cog):
                 epic_lines.append(
                     f"{e['artist_name']} – {e['title']} #{e['epic_number']}"
                 )
-            more = "" if len(epics) <= 15 else f"\n… {len(epics) - 15} weitere"
+            more = "" if len(epics) <= 15 else f"\n… {len(epics) - 15} more"
             embed.add_field(name=f"💎 Epics ({len(epics)})", value="\n".join(epic_lines) + more, inline=False)
         else:
-            embed.add_field(name="💎 Epics", value="Keine Epics", inline=False)
+            embed.add_field(name="💎 Epics", value="No epics", inline=False)
         # Favourite artists with badge
         if favs:
             fa_lines: list[str] = []
@@ -562,31 +562,31 @@ class ProfileCog(commands.Cog):
                 badge = a["badge"]
                 badge_str = f" — {badge}" if badge else ""
                 fa_lines.append(f"{a['name']}{badge_str}")
-            more = "" if len(favs) <= 15 else f"\n… {len(favs) - 15} weitere"
-            embed.add_field(name=f"🌟 Lieblingskünstler ({len(favs)})", value="\n".join(fa_lines) + more, inline=False)
+            more = "" if len(favs) <= 15 else f"\n… {len(favs) - 15} more"
+            embed.add_field(name=f"🌟 Favorite Artists ({len(favs)})", value="\n".join(fa_lines) + more, inline=False)
         else:
-            embed.add_field(name="🌟 Lieblingskünstler", value="Keine Lieblingskünstler", inline=False)
+            embed.add_field(name="🌟 Favorite Artists", value="No favorite artists", inline=False)
         # Wishlist
         if wishlist:
             wl_lines: list[str] = []
             for w in wishlist[:15]:
                 note_part = f" — _{w['note']}_" if w['note'] else ""
                 wl_lines.append(f"{w['artist_name']} – {w['title']}{note_part}")
-            more = "" if len(wishlist) <= 15 else f"\n… {len(wishlist) - 15} weitere"
-            embed.add_field(name=f"🎯 Wunschliste ({len(wishlist)})", value="\n".join(wl_lines) + more, inline=False)
+            more = "" if len(wishlist) <= 15 else f"\n… {len(wishlist) - 15} more"
+            embed.add_field(name=f"🎯 Wishlist ({len(wishlist)})", value="\n".join(wl_lines) + more, inline=False)
         else:
-            embed.add_field(name="🎯 Wunschliste", value="Keine Wünsche", inline=False)
+            embed.add_field(name="🎯 Wishlist", value="No wishes", inline=False)
 
         await interaction.response.send_message(embed=embed, ephemeral=(user is None))
 
     # Command: wishcurrent (current song as wishlist)
-    @app_commands.command(name="wishcurrent", description="Füge den aktuell gespielten Song (Spotify) zur Wunschliste hinzu")
+    @app_commands.command(name="wishcurrent", description="Add the currently playing song (Spotify) to your wishlist")
     async def wishcurrent(self, interaction: discord.Interaction) -> None:
         # Check if user has Spotify activity visible
         activity = next((a for a in interaction.user.activities if isinstance(a, discord.Spotify)), None)
         if not activity:
             await interaction.response.send_message(
-                "Ich sehe keinen aktuell gespielten Spotify-Song oder du hast deine Aktivität verborgen.",
+                "I don't see a currently playing Spotify song or you've hidden your activity.",
                 ephemeral=True,
             )
             return
@@ -606,24 +606,24 @@ class ProfileCog(commands.Cog):
                 (user_id, track_id, None),
             )
         await interaction.response.send_message(
-            f"✅ Wunsch hinzugefügt: **{activity.artist} – {activity.title}**.",
+            f"✅ Wish added: **{activity.artist} – {activity.title}**.",
             ephemeral=True,
         )
 
-    # ---------- UPDATED: favartistcurrent normalisiert über Spotify ----------
-    @app_commands.command(name="favartistcurrent", description="Setze den aktuell gespielten Künstler als Lieblingskünstler")
+    # ---------- UPDATED: favartistcurrent normalized via Spotify ----------
+    @app_commands.command(name="favartistcurrent", description="Add the currently playing artist as a favorite artist")
     async def favartistcurrent(self, interaction: discord.Interaction) -> None:
         activity = next((a for a in interaction.user.activities if isinstance(a, discord.Spotify)), None)
         if not activity:
             await interaction.response.send_message(
-                "Ich sehe keinen aktuell gespielten Spotify-Song oder du hast deine Aktivität verborgen.",
+                "I don't see a currently playing Spotify song or you've hidden your activity.",
                 ephemeral=True,
             )
             return
         user_id = str(interaction.user.id)
         await self.ensure_user(user_id)
 
-        # Normalisierung über Spotify
+        # Normalization via Spotify
         sp = await spotify.get_canonical_artist(activity.artist)
         canonical_name = sp["name"] if sp else activity.artist
 
@@ -641,6 +641,6 @@ class ProfileCog(commands.Cog):
             (user_id, artist_id_int),
         )
         await interaction.response.send_message(
-            f"✅ Lieblingskünstler hinzugefügt: **{canonical_name}**.",
+            f"✅ Favorite artist added: **{canonical_name}**.",
             ephemeral=True,
         )

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -45,7 +45,7 @@ def test_addepic_rejects_non_positive_number(monkeypatch):
 
     interaction = DummyInteraction()
     asyncio.run(ProfileCog.addepic.callback(cog, interaction, "abc", 0))
-    assert interaction.response.message == "Epic-Nummer muss > 0 sein."
+    assert interaction.response.message == "Epic number must be > 0."
     asyncio.run(bot.close())
 
 
@@ -85,7 +85,7 @@ def test_addepic_inserts_epic(monkeypatch):
     asyncio.run(ProfileCog.addepic.callback(cog, interaction, "abc", 5))
 
     assert dummy_execute.called
-    assert "✅ Epic hinzugefügt" in interaction.response.message
+    assert "✅ Epic added" in interaction.response.message
     asyncio.run(bot.close())
 
 
@@ -105,7 +105,7 @@ def test_addwish_song_not_found(monkeypatch):
     interaction = DummyInteraction()
     asyncio.run(ProfileCog.addwish.callback(cog, interaction, "abc", None))
 
-    assert interaction.response.message == "Song nicht gefunden."
+    assert interaction.response.message == "Song not found."
     asyncio.run(bot.close())
 
 
@@ -141,5 +141,5 @@ def test_addwish_inserts_song(monkeypatch):
     asyncio.run(ProfileCog.addwish.callback(cog, interaction, "abc", None))
 
     assert dummy_execute.called
-    assert interaction.response.message == "✅ Zur Wunschliste hinzugefügt."
+    assert interaction.response.message == "✅ Added to wishlist."
     asyncio.run(bot.close())

--- a/tests/test_username.py
+++ b/tests/test_username.py
@@ -53,7 +53,7 @@ def test_username_command_updates_db(monkeypatch):
     asyncio.run(ProfileCog.username.callback(cog, interaction, "Player1"))
 
     assert executed["params"] == ("Player1", "1")
-    assert "Username gesetzt" in interaction.response.message
+    assert "Username set" in interaction.response.message
     asyncio.run(bot.close())
 
 
@@ -78,6 +78,7 @@ def test_profile_shows_username(monkeypatch):
     interaction = DummyInteraction()
     asyncio.run(ProfileCog.profile.callback(cog, interaction, None))
     embed = interaction.response.kwargs["embed"]
+    assert embed.title == "🎵 User1's Collection"
     assert embed.fields[0].name == "👤 SM-Username"
     assert embed.fields[0].value == "PlayerX"
     asyncio.run(bot.close())


### PR DESCRIPTION
## Summary
- Translate profile commands, responses, and embed text from German to English
- Update tests to expect English messages
- Set profile embed title to display user's collection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68988279c388832b8a1c6f9f87b89a9a