### PR TITLE
Use 'Soundmap Collection' in profile header

### DIFF
--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -538,7 +538,7 @@ class ProfileCog(commands.Cog):
         )
         # Build embed
         embed = discord.Embed(
-            title=f"🎵 Soundmap profile of {member.display_name}",
+            title=f"🎵 {member.display_name}'s Soundmap Collection",
             color=discord.Color.purple(),
         )
         if username:


### PR DESCRIPTION
## Summary
- display "<username>'s Soundmap Collection" as the profile embed title

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68988c68bb64832b9d72597134a0f621