### PR TITLE
Refactor profile sorting system

### DIFF
--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -64,9 +64,69 @@ class MoveEpicView(discord.ui.View):
         pos = await self._get_position()
         await self.cog.move_epic_to(self.user_id, self.track_id, self.epic_number, pos + 1)
         pos = await self._get_position()
-        await interaction.response.edit_message(
-            content=f"Current position: {pos}", view=self
+        await interaction.response.edit_message(content=f"Current position: {pos}", view=self)
+
+
+class MoveArtistView(discord.ui.View):
+    """UI view to move a favorite artist up or down."""
+
+    def __init__(self, cog: "ProfileCog", user_id: str, artist_id: int) -> None:
+        super().__init__()
+        self.cog = cog
+        self.user_id = user_id
+        self.artist_id = artist_id
+
+    async def _get_position(self) -> int:
+        row = await db.fetch_one(
+            "SELECT position FROM user_fav_artists WHERE user_id=? AND artist_id=?",
+            (self.user_id, self.artist_id),
         )
+        return row["position"] if row else 0
+
+    @discord.ui.button(emoji="⬆️", style=discord.ButtonStyle.secondary)
+    async def move_up(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        pos = await self._get_position()
+        await self.cog.move_artist_to(self.user_id, self.artist_id, pos - 1)
+        pos = await self._get_position()
+        await interaction.response.edit_message(content=f"Current position: {pos}", view=self)
+
+    @discord.ui.button(emoji="⬇️", style=discord.ButtonStyle.secondary)
+    async def move_down(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        pos = await self._get_position()
+        await self.cog.move_artist_to(self.user_id, self.artist_id, pos + 1)
+        pos = await self._get_position()
+        await interaction.response.edit_message(content=f"Current position: {pos}", view=self)
+
+
+class MoveWishView(discord.ui.View):
+    """UI view to move a wishlist entry up or down."""
+
+    def __init__(self, cog: "ProfileCog", user_id: str, track_id: str) -> None:
+        super().__init__()
+        self.cog = cog
+        self.user_id = user_id
+        self.track_id = track_id
+
+    async def _get_position(self) -> int:
+        row = await db.fetch_one(
+            "SELECT position FROM user_wishlist_epics WHERE user_id=? AND track_id=?",
+            (self.user_id, self.track_id),
+        )
+        return row["position"] if row else 0
+
+    @discord.ui.button(emoji="⬆️", style=discord.ButtonStyle.secondary)
+    async def move_up(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        pos = await self._get_position()
+        await self.cog.move_wish_to(self.user_id, self.track_id, pos - 1)
+        pos = await self._get_position()
+        await interaction.response.edit_message(content=f"Current position: {pos}", view=self)
+
+    @discord.ui.button(emoji="⬇️", style=discord.ButtonStyle.secondary)
+    async def move_down(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        pos = await self._get_position()
+        await self.cog.move_wish_to(self.user_id, self.track_id, pos + 1)
+        pos = await self._get_position()
+        await interaction.response.edit_message(content=f"Current position: {pos}", view=self)
 
 
 class ProfileCog(commands.Cog):
@@ -88,7 +148,24 @@ class ProfileCog(commands.Cog):
             "SELECT COALESCE(MAX(position), 0) AS maxp FROM user_epics WHERE user_id=?",
             (user_id,),
         )
-        return (row["maxp"] or 0) + 1
+        maxp = row["maxp"] if row and row["maxp"] is not None else 0
+        return maxp + 1
+
+    async def get_next_artist_position(self, user_id: str) -> int:
+        row = await db.fetch_one(
+            "SELECT COALESCE(MAX(position),0) AS maxp FROM user_fav_artists WHERE user_id=?",
+            (user_id,),
+        )
+        maxp = row["maxp"] if row and row["maxp"] is not None else 0
+        return maxp + 1
+
+    async def get_next_wish_position(self, user_id: str) -> int:
+        row = await db.fetch_one(
+            "SELECT COALESCE(MAX(position),0) AS maxp FROM user_wishlist_epics WHERE user_id=?",
+            (user_id,),
+        )
+        maxp = row["maxp"] if row and row["maxp"] is not None else 0
+        return maxp + 1
 
     async def move_epic_to(self, user_id: str, track_id: str, epic_number: int, new_pos: int) -> None:
         """Reposition an Epic in manual ordering, adjusting other positions accordingly."""
@@ -142,6 +219,187 @@ class ProfileCog(commands.Cog):
                 """,
                 (new_pos, user_id, track_id, epic_number),
             )
+
+    async def move_artist_to(self, user_id: str, artist_id: int, new_pos: int) -> None:
+        row = await db.fetch_one(
+            "SELECT position FROM user_fav_artists WHERE user_id=? AND artist_id=?",
+            (user_id, artist_id),
+        )
+        if row is None:
+            raise ValueError("Artist not found for this user.")
+        old_pos = row["position"] or 1
+        if new_pos < 1:
+            new_pos = 1
+        max_row = await db.fetch_one(
+            "SELECT COALESCE(MAX(position),0) AS maxp FROM user_fav_artists WHERE user_id=?",
+            (user_id,),
+        )
+        max_pos = max_row["maxp"] or 1
+        if new_pos > max_pos:
+            new_pos = max_pos
+        if old_pos == new_pos:
+            return
+        async with db.transaction():
+            if new_pos < old_pos:
+                await db.execute(
+                    """
+                    UPDATE user_fav_artists
+                    SET position = position + 1
+                    WHERE user_id=? AND position >= ? AND position < ?
+                    """,
+                    (user_id, new_pos, old_pos),
+                )
+            else:
+                await db.execute(
+                    """
+                    UPDATE user_fav_artists
+                    SET position = position - 1
+                    WHERE user_id=? AND position <= ? AND position > ?
+                    """,
+                    (user_id, new_pos, old_pos),
+                )
+            await db.execute(
+                """
+                UPDATE user_fav_artists
+                SET position=?
+                WHERE user_id=? AND artist_id=?
+                """,
+                (new_pos, user_id, artist_id),
+            )
+
+    async def move_wish_to(self, user_id: str, track_id: str, new_pos: int) -> None:
+        row = await db.fetch_one(
+            "SELECT position FROM user_wishlist_epics WHERE user_id=? AND track_id=?",
+            (user_id, track_id),
+        )
+        if row is None:
+            raise ValueError("Wish not found for this user.")
+        old_pos = row["position"] or 1
+        if new_pos < 1:
+            new_pos = 1
+        max_row = await db.fetch_one(
+            "SELECT COALESCE(MAX(position),0) AS maxp FROM user_wishlist_epics WHERE user_id=?",
+            (user_id,),
+        )
+        max_pos = max_row["maxp"] or 1
+        if new_pos > max_pos:
+            new_pos = max_pos
+        if old_pos == new_pos:
+            return
+        async with db.transaction():
+            if new_pos < old_pos:
+                await db.execute(
+                    """
+                    UPDATE user_wishlist_epics
+                    SET position = position + 1
+                    WHERE user_id=? AND position >= ? AND position < ?
+                    """,
+                    (user_id, new_pos, old_pos),
+                )
+            else:
+                await db.execute(
+                    """
+                    UPDATE user_wishlist_epics
+                    SET position = position - 1
+                    WHERE user_id=? AND position <= ? AND position > ?
+                    """,
+                    (user_id, new_pos, old_pos),
+                )
+            await db.execute(
+                """
+                UPDATE user_wishlist_epics
+                SET position=?
+                WHERE user_id=? AND track_id=?
+                """,
+                (new_pos, user_id, track_id),
+            )
+
+    async def reorder_epics(self, user_id: str, mode: str) -> None:
+        if mode == "name":
+            rows = await db.fetch_all(
+                """
+                SELECT ue.track_id, ue.epic_number
+                FROM user_epics ue
+                JOIN tracks t ON t.track_id = ue.track_id
+                WHERE ue.user_id=?
+                ORDER BY t.title COLLATE NOCASE ASC, ue.epic_number ASC
+                """,
+                (user_id,),
+            )
+        else:
+            rows = await db.fetch_all(
+                """
+                SELECT track_id, epic_number
+                FROM user_epics
+                WHERE user_id=?
+                ORDER BY added_at ASC, rowid ASC
+                """,
+                (user_id,),
+            )
+        async with db.transaction():
+            for idx, r in enumerate(rows, start=1):
+                await db.execute(
+                    "UPDATE user_epics SET position=? WHERE user_id=? AND track_id=? AND epic_number=?",
+                    (idx, user_id, r["track_id"], r["epic_number"]),
+                )
+
+    async def reorder_artists(self, user_id: str, mode: str) -> None:
+        if mode == "name":
+            rows = await db.fetch_all(
+                """
+                SELECT ufa.artist_id
+                FROM user_fav_artists ufa
+                JOIN artists a ON a.artist_id = ufa.artist_id
+                WHERE ufa.user_id=?
+                ORDER BY a.name COLLATE NOCASE ASC
+                """,
+                (user_id,),
+            )
+        else:
+            rows = await db.fetch_all(
+                """
+                SELECT artist_id
+                FROM user_fav_artists
+                WHERE user_id=?
+                ORDER BY added_at ASC, rowid ASC
+                """,
+                (user_id,),
+            )
+        async with db.transaction():
+            for idx, r in enumerate(rows, start=1):
+                await db.execute(
+                    "UPDATE user_fav_artists SET position=? WHERE user_id=? AND artist_id=?",
+                    (idx, user_id, r["artist_id"]),
+                )
+
+    async def reorder_wishlist(self, user_id: str, mode: str) -> None:
+        if mode == "name":
+            rows = await db.fetch_all(
+                """
+                SELECT uw.track_id
+                FROM user_wishlist_epics uw
+                JOIN tracks t ON t.track_id = uw.track_id
+                WHERE uw.user_id=?
+                ORDER BY t.title COLLATE NOCASE ASC
+                """,
+                (user_id,),
+            )
+        else:
+            rows = await db.fetch_all(
+                """
+                SELECT track_id
+                FROM user_wishlist_epics
+                WHERE user_id=?
+                ORDER BY added_at ASC, rowid ASC
+                """,
+                (user_id,),
+            )
+        async with db.transaction():
+            for idx, r in enumerate(rows, start=1):
+                await db.execute(
+                    "UPDATE user_wishlist_epics SET position=? WHERE user_id=? AND track_id=?",
+                    (idx, user_id, r["track_id"]),
+                )
 
     # Slash commands
     # Autocomplete for track selection reused across commands
@@ -205,6 +463,64 @@ class ProfileCog(commands.Cog):
             results = []
         # Return the name as the value; the DB insert handles creation
         return [app_commands.Choice(name=a["name"][:100], value=a["name"]) for a in results][:25]
+
+    # Autocomplete helpers for manual sorting
+    async def autocomplete_user_artists_for_sort(self, interaction: discord.Interaction, current: str) -> List[app_commands.Choice[str]]:
+        user_id = str(interaction.user.id)
+        term = (current or "").strip()
+        rows = await db.fetch_all(
+            """
+            SELECT a.name
+            FROM user_fav_artists ufa
+            JOIN artists a ON a.artist_id = ufa.artist_id
+            WHERE ufa.user_id=? AND a.name LIKE ?
+            ORDER BY a.name COLLATE NOCASE
+            LIMIT 25
+            """,
+            (user_id, f"%{term}%"),
+        )
+        return [app_commands.Choice(name=r["name"], value=r["name"]) for r in rows]
+
+    async def autocomplete_owned_epic_tracks(self, interaction: discord.Interaction, current: str) -> List[app_commands.Choice[str]]:
+        user_id = str(interaction.user.id)
+        term = (current or "").strip()
+        rows = await db.fetch_all(
+            """
+            SELECT DISTINCT t.track_id, t.title, t.artist_name
+            FROM user_epics ue
+            JOIN tracks t ON t.track_id = ue.track_id
+            WHERE ue.user_id=? AND (t.title LIKE ? OR t.artist_name LIKE ?)
+            ORDER BY t.artist_name COLLATE NOCASE, t.title COLLATE NOCASE
+            LIMIT 25
+            """,
+            (user_id, f"%{term}%", f"%{term}%"),
+        )
+        return [app_commands.Choice(name=f"{r['artist_name']} – {r['title']}", value=r['track_id']) for r in rows]
+
+    async def autocomplete_wishlist_tracks(self, interaction: discord.Interaction, current: str) -> List[app_commands.Choice[str]]:
+        user_id = str(interaction.user.id)
+        term = (current or "").strip()
+        rows = await db.fetch_all(
+            """
+            SELECT t.track_id, t.title, t.artist_name
+            FROM user_wishlist_epics uw
+            JOIN tracks t ON t.track_id = uw.track_id
+            WHERE uw.user_id=? AND (t.title LIKE ? OR t.artist_name LIKE ?)
+            ORDER BY t.artist_name COLLATE NOCASE, t.title COLLATE NOCASE
+            LIMIT 25
+            """,
+            (user_id, f"%{term}%", f"%{term}%"),
+        )
+        return [app_commands.Choice(name=f"{r['artist_name']} – {r['title']}", value=r['track_id']) for r in rows]
+
+    async def autocomplete_sort_item(self, interaction: discord.Interaction, current: str) -> List[app_commands.Choice[str]]:
+        target = getattr(interaction.namespace, "subject", None)
+        if target == "artist":
+            return await self.autocomplete_user_artists_for_sort(interaction, current)
+        elif target == "wish":
+            return await self.autocomplete_wishlist_tracks(interaction, current)
+        else:
+            return await self.autocomplete_owned_epic_tracks(interaction, current)
 
     @app_commands.command(name="username", description="Set your Soundmap in-game username")
     @app_commands.describe(name="Your new in-game username")
@@ -343,9 +659,10 @@ class ProfileCog(commands.Cog):
             )
             msg = "Wishlist note updated."
         else:
+            next_pos = await self.get_next_wish_position(user_id)
             await db.execute(
-                "INSERT INTO user_wishlist_epics(user_id, track_id, note) VALUES(?,?,?)",
-                (user_id, t["track_id"], note),
+                "INSERT INTO user_wishlist_epics(user_id, track_id, note, position) VALUES(?,?,?,?)",
+                (user_id, t["track_id"], note, next_pos),
             )
             msg = "✅ Added to wishlist."
         await interaction.response.send_message(msg, ephemeral=True)
@@ -357,16 +674,26 @@ class ProfileCog(commands.Cog):
     async def delwish(self, interaction: discord.Interaction, track: str) -> None:
         user_id = str(interaction.user.id)
         row = await db.fetch_one(
-            "SELECT 1 FROM user_wishlist_epics WHERE user_id=? AND track_id=?",
+            "SELECT position FROM user_wishlist_epics WHERE user_id=? AND track_id=?",
             (user_id, track),
         )
         if not row:
             await interaction.response.send_message("This song is not on your wishlist.", ephemeral=True)
             return
-        await db.execute(
-            "DELETE FROM user_wishlist_epics WHERE user_id=? AND track_id=?",
-            (user_id, track),
-        )
+        pos = row["position"] or 1
+        async with db.transaction():
+            await db.execute(
+                "DELETE FROM user_wishlist_epics WHERE user_id=? AND track_id=?",
+                (user_id, track),
+            )
+            await db.execute(
+                """
+                UPDATE user_wishlist_epics
+                SET position = position - 1
+                WHERE user_id=? AND position > ?
+                """,
+                (user_id, pos),
+            )
         await interaction.response.send_message("✅ Removed from wishlist.", ephemeral=True)
 
     # ---------- UPDATED: add favourite artist (Spotify validation) ----------
@@ -395,9 +722,10 @@ class ProfileCog(commands.Cog):
         artist_id_int = row["artist_id"]
 
         # Set favorite artist
+        next_pos = await self.get_next_artist_position(user_id)
         await db.execute(
-            "INSERT INTO user_fav_artists(user_id, artist_id) VALUES(?,?) ON CONFLICT(user_id, artist_id) DO NOTHING",
-            (user_id, artist_id_int),
+            "INSERT INTO user_fav_artists(user_id, artist_id, position) VALUES(?,?,?) ON CONFLICT(user_id, artist_id) DO NOTHING",
+            (user_id, artist_id_int, next_pos),
         )
         await interaction.response.send_message(f"✅ Favorite artist added: **{canonical_name}**.", ephemeral=True)
 
@@ -423,17 +751,26 @@ class ProfileCog(commands.Cog):
         artist_id_int = row["artist_id"]
 
         fav_row = await db.fetch_one(
-            "SELECT 1 FROM user_fav_artists WHERE user_id=? AND artist_id=?",
+            "SELECT position FROM user_fav_artists WHERE user_id=? AND artist_id=?",
             (user_id, artist_id_int),
         )
         if not fav_row:
             await interaction.response.send_message("This artist is not in your list.", ephemeral=True)
             return
-
-        await db.execute(
-            "DELETE FROM user_fav_artists WHERE user_id=? AND artist_id=?",
-            (user_id, artist_id_int),
-        )
+        pos = fav_row["position"] or 1
+        async with db.transaction():
+            await db.execute(
+                "DELETE FROM user_fav_artists WHERE user_id=? AND artist_id=?",
+                (user_id, artist_id_int),
+            )
+            await db.execute(
+                """
+                UPDATE user_fav_artists
+                SET position = position - 1
+                WHERE user_id=? AND position > ?
+                """,
+                (user_id, pos),
+            )
         await interaction.response.send_message(
             f"✅ Favorite artist removed: **{canonical_name}**.", ephemeral=True
         )
@@ -463,60 +800,127 @@ class ProfileCog(commands.Cog):
         artist_id_int = row["artist_id"]
 
         # Upsert favourite artist row with badge
+        next_pos = await self.get_next_artist_position(user_id)
         await db.execute(
             """
-            INSERT INTO user_fav_artists(user_id, artist_id, badge)
-            VALUES(?,?,?)
+            INSERT INTO user_fav_artists(user_id, artist_id, badge, position)
+            VALUES(?,?,?,?)
             ON CONFLICT(user_id, artist_id) DO UPDATE SET badge=excluded.badge
             """,
-            (user_id, artist_id_int, badge.value),
+            (user_id, artist_id_int, badge.value, next_pos),
         )
         await interaction.response.send_message(f"✅ Badge **{badge.value}** set for **{canonical_name}**.", ephemeral=True)
 
-    # Command: set epic sort mode
-    @app_commands.command(name="set_epic_sort", description="Choose how your Epics are sorted in the profile")
-    @app_commands.choices(mode=[
-        app_commands.Choice(name="Added order", value="added"),
-        app_commands.Choice(name="By artist", value="artist"),
-        app_commands.Choice(name="Manual", value="manual"),
-    ])
-    async def set_epic_sort(self, interaction: discord.Interaction, mode: app_commands.Choice[str]) -> None:
-        user_id = str(interaction.user.id)
-        await self.ensure_user(user_id)
-        await db.execute(
-            "INSERT INTO users(user_id, epic_sort_mode) VALUES(?,?) ON CONFLICT(user_id) DO UPDATE SET epic_sort_mode=excluded.epic_sort_mode",
-            (user_id, mode.value),
-        )
-        await interaction.response.send_message(
-            f"✅ Sort mode set to **{mode.name}**.",
-            ephemeral=True,
-        )
-
-    # Command: move epic manually
-    @app_commands.command(
-        name="move_epic", description="Interactively move one of your Epics"
+    # Unified sorting command for artists, epics and wishlist
+    @app_commands.command(name="sort", description="Sort your artists, epics or wishlist")
+    @app_commands.choices(
+        subject=[
+            app_commands.Choice(name="Artist", value="artist"),
+            app_commands.Choice(name="Epic", value="epic"),
+            app_commands.Choice(name="Wish", value="wish"),
+        ],
+        mode=[
+            app_commands.Choice(name="Sort by name", value="name"),
+            app_commands.Choice(name="Sort by added order", value="added"),
+            app_commands.Choice(name="Manual", value="manual"),
+        ],
     )
-    @app_commands.autocomplete(track=autocomplete_tracks)
-    @app_commands.describe(epic_number="The Epic's serial number to move")
-    async def move_epic(
-        self, interaction: discord.Interaction, track: str, epic_number: int
+    @app_commands.describe(
+        item="Artist or song to move when using manual mode",
+        epic_number="Epic number when sorting Epics manually",
+    )
+    @app_commands.autocomplete(item=autocomplete_sort_item)
+    async def sort(
+        self,
+        interaction: discord.Interaction,
+        subject: app_commands.Choice[str],
+        mode: app_commands.Choice[str],
+        item: Optional[str] = None,
+        epic_number: Optional[int] = None,
     ) -> None:
         user_id = str(interaction.user.id)
-        row = await db.fetch_one(
-            "SELECT position FROM user_epics WHERE user_id=? AND track_id=? AND epic_number=?",
-            (user_id, track, epic_number),
-        )
-        if row is None:
+        await self.ensure_user(user_id)
+        column_map = {
+            "artist": "artist_sort_mode",
+            "epic": "epic_sort_mode",
+            "wish": "wish_sort_mode",
+        }
+        column = column_map[subject.value]
+        if mode.value != "manual":
+            await db.execute(
+                f"INSERT INTO users(user_id, {column}) VALUES(?,?) ON CONFLICT(user_id) DO UPDATE SET {column}=excluded.{column}",
+                (user_id, mode.value),
+            )
+            if subject.value == "artist":
+                await self.reorder_artists(user_id, mode.value)
+            elif subject.value == "epic":
+                await self.reorder_epics(user_id, mode.value)
+            else:
+                await self.reorder_wishlist(user_id, mode.value)
             await interaction.response.send_message(
-                "Epic not found for this user.", ephemeral=True
+                f"✅ {subject.name} sorted by {mode.name}.", ephemeral=True
             )
             return
-        view = MoveEpicView(self, user_id, track, epic_number)
-        await interaction.response.send_message(
-            f"Current position: {row['position']}. Use the buttons to move the Epic.",
-            view=view,
-            ephemeral=True,
+        await db.execute(
+            f"INSERT INTO users(user_id, {column}) VALUES(?,?) ON CONFLICT(user_id) DO UPDATE SET {column}=excluded.{column}",
+            (user_id, "manual"),
         )
+        if subject.value == "artist":
+            if not item:
+                await interaction.response.send_message("Select an artist to move.", ephemeral=True)
+                return
+            row = await db.fetch_one(
+                """
+                SELECT ufa.artist_id, ufa.position
+                FROM user_fav_artists ufa
+                JOIN artists a ON a.artist_id = ufa.artist_id
+                WHERE ufa.user_id=? AND a.name=?
+                """,
+                (user_id, item),
+            )
+            if not row:
+                await interaction.response.send_message("Artist not in your favorites.", ephemeral=True)
+                return
+            view = MoveArtistView(self, user_id, row["artist_id"])
+            await interaction.response.send_message(
+                f"Current position: {row['position']}. Use the buttons to move the artist.",
+                view=view,
+                ephemeral=True,
+            )
+        elif subject.value == "epic":
+            if not item or epic_number is None:
+                await interaction.response.send_message("Provide song and epic number.", ephemeral=True)
+                return
+            row = await db.fetch_one(
+                "SELECT position FROM user_epics WHERE user_id=? AND track_id=? AND epic_number=?",
+                (user_id, item, epic_number),
+            )
+            if not row:
+                await interaction.response.send_message("Epic not found for this user.", ephemeral=True)
+                return
+            view = MoveEpicView(self, user_id, item, epic_number)
+            await interaction.response.send_message(
+                f"Current position: {row['position']}. Use the buttons to move the Epic.",
+                view=view,
+                ephemeral=True,
+            )
+        else:
+            if not item:
+                await interaction.response.send_message("Select a song from your wishlist.", ephemeral=True)
+                return
+            row = await db.fetch_one(
+                "SELECT position FROM user_wishlist_epics WHERE user_id=? AND track_id=?",
+                (user_id, item),
+            )
+            if not row:
+                await interaction.response.send_message("This song is not on your wishlist.", ephemeral=True)
+                return
+            view = MoveWishView(self, user_id, item)
+            await interaction.response.send_message(
+                f"Current position: {row['position']}. Use the buttons to move the wish.",
+                view=view,
+                ephemeral=True,
+            )
 
     # Command: show profile
     @app_commands.command(name="profile", description="Show your Soundmap profile")
@@ -524,25 +928,28 @@ class ProfileCog(commands.Cog):
         member = user or interaction.user
         user_id = str(member.id)
         await self.ensure_user(user_id)
-        # Fetch username and sort mode
+        # Fetch username and sort modes
         row = await db.fetch_one(
-            "SELECT username, epic_sort_mode FROM users WHERE user_id=?", (user_id,)
+            "SELECT username, epic_sort_mode, artist_sort_mode, wish_sort_mode FROM users WHERE user_id=?",
+            (user_id,),
         )
         username = row["username"] if row else None
-        sort_mode = row["epic_sort_mode"] if row else "added"
+        epic_sort = row["epic_sort_mode"] if row else "added"
+        artist_sort = row["artist_sort_mode"] if row else "name"
+        wish_sort = row["wish_sort_mode"] if row else "name"
         # Fetch epics sorted accordingly
-        if sort_mode == "artist":
+        if epic_sort == "name":
             epics = await db.fetch_all(
                 """
                 SELECT ue.epic_number, t.title, t.artist_name, t.url
                 FROM user_epics ue
                 JOIN tracks t ON t.track_id = ue.track_id
                 WHERE ue.user_id=?
-                ORDER BY t.artist_name COLLATE NOCASE ASC, t.title COLLATE NOCASE ASC, ue.epic_number ASC
+                ORDER BY t.title COLLATE NOCASE ASC, ue.epic_number ASC
                 """,
                 (user_id,),
             )
-        elif sort_mode == "manual":
+        elif epic_sort == "manual":
             epics = await db.fetch_all(
                 """
                 SELECT ue.epic_number, t.title, t.artist_name, t.url
@@ -554,7 +961,6 @@ class ProfileCog(commands.Cog):
                 (user_id,),
             )
         else:
-            # added order
             epics = await db.fetch_all(
                 """
                 SELECT ue.epic_number, t.title, t.artist_name, t.url, ue.added_at
@@ -565,28 +971,74 @@ class ProfileCog(commands.Cog):
                 """,
                 (user_id,),
             )
-        # Fetch wishlist
-        wishlist = await db.fetch_all(
-            """
-            SELECT t.title, t.artist_name, uw.note, t.url
-            FROM user_wishlist_epics uw
-            JOIN tracks t ON t.track_id = uw.track_id
-            WHERE uw.user_id=?
-            ORDER BY t.artist_name COLLATE NOCASE ASC, t.title COLLATE NOCASE ASC
-            """,
-            (user_id,),
-        )
+        # Fetch wishlist sorted accordingly
+        if wish_sort == "name":
+            wishlist = await db.fetch_all(
+                """
+                SELECT t.title, t.artist_name, uw.note, t.url
+                FROM user_wishlist_epics uw
+                JOIN tracks t ON t.track_id = uw.track_id
+                WHERE uw.user_id=?
+                ORDER BY t.title COLLATE NOCASE ASC
+                """,
+                (user_id,),
+            )
+        elif wish_sort == "manual":
+            wishlist = await db.fetch_all(
+                """
+                SELECT t.title, t.artist_name, uw.note, t.url
+                FROM user_wishlist_epics uw
+                JOIN tracks t ON t.track_id = uw.track_id
+                WHERE uw.user_id=?
+                ORDER BY uw.position ASC
+                """,
+                (user_id,),
+            )
+        else:
+            wishlist = await db.fetch_all(
+                """
+                SELECT t.title, t.artist_name, uw.note, t.url
+                FROM user_wishlist_epics uw
+                JOIN tracks t ON t.track_id = uw.track_id
+                WHERE uw.user_id=?
+                ORDER BY uw.added_at ASC, uw.rowid ASC
+                """,
+                (user_id,),
+            )
         # Fetch fav artists & badges
-        favs = await db.fetch_all(
-            """
-            SELECT a.name, ufa.badge
-            FROM user_fav_artists ufa
-            JOIN artists a ON a.artist_id = ufa.artist_id
-            WHERE ufa.user_id=?
-            ORDER BY a.name COLLATE NOCASE
-            """,
-            (user_id,),
-        )
+        if artist_sort == "name":
+            favs = await db.fetch_all(
+                """
+                SELECT a.name, ufa.badge
+                FROM user_fav_artists ufa
+                JOIN artists a ON a.artist_id = ufa.artist_id
+                WHERE ufa.user_id=?
+                ORDER BY a.name COLLATE NOCASE
+                """,
+                (user_id,),
+            )
+        elif artist_sort == "manual":
+            favs = await db.fetch_all(
+                """
+                SELECT a.name, ufa.badge
+                FROM user_fav_artists ufa
+                JOIN artists a ON a.artist_id = ufa.artist_id
+                WHERE ufa.user_id=?
+                ORDER BY ufa.position ASC
+                """,
+                (user_id,),
+            )
+        else:
+            favs = await db.fetch_all(
+                """
+                SELECT a.name, ufa.badge
+                FROM user_fav_artists ufa
+                JOIN artists a ON a.artist_id = ufa.artist_id
+                WHERE ufa.user_id=?
+                ORDER BY ufa.added_at ASC, ufa.rowid ASC
+                """,
+                (user_id,),
+            )
         # Build embed
         embed = discord.Embed(
             title=f"🎵 {member.display_name}'s Soundmap Collection",
@@ -652,9 +1104,10 @@ class ProfileCog(commands.Cog):
             (user_id, track_id),
         )
         if not row:
+            next_pos = await self.get_next_wish_position(user_id)
             await db.execute(
-                "INSERT INTO user_wishlist_epics(user_id, track_id, note) VALUES(?,?,?)",
-                (user_id, track_id, None),
+                "INSERT INTO user_wishlist_epics(user_id, track_id, note, position) VALUES(?,?,?,?)",
+                (user_id, track_id, None, next_pos),
             )
         await interaction.response.send_message(
             f"✅ Wish added: **{activity.artist} – {activity.title}**.",
@@ -687,9 +1140,10 @@ class ProfileCog(commands.Cog):
         artist_id_int = row["artist_id"]
 
         # Add favourite
+        next_pos = await self.get_next_artist_position(user_id)
         await db.execute(
-            "INSERT INTO user_fav_artists(user_id, artist_id) VALUES(?,?) ON CONFLICT(user_id, artist_id) DO NOTHING",
-            (user_id, artist_id_int),
+            "INSERT INTO user_fav_artists(user_id, artist_id, position) VALUES(?,?,?) ON CONFLICT(user_id, artist_id) DO NOTHING",
+            (user_id, artist_id_int, next_pos),
         )
         await interaction.response.send_message(
             f"✅ Favorite artist added: **{canonical_name}**.",

--- a/core/db.py
+++ b/core/db.py
@@ -64,6 +64,22 @@ async def init_db() -> None:
         # Column already exists or cannot be added; ignore
         pass
 
+    # Additional columns for sorting and manual ordering
+    alter_statements = [
+        "ALTER TABLE users ADD COLUMN artist_sort_mode TEXT NOT NULL DEFAULT 'name'",
+        "ALTER TABLE users ADD COLUMN wish_sort_mode TEXT NOT NULL DEFAULT 'name'",
+        "ALTER TABLE user_wishlist_epics ADD COLUMN added_at TEXT DEFAULT CURRENT_TIMESTAMP",
+        "ALTER TABLE user_wishlist_epics ADD COLUMN position INTEGER",
+        "ALTER TABLE user_fav_artists ADD COLUMN added_at TEXT DEFAULT CURRENT_TIMESTAMP",
+        "ALTER TABLE user_fav_artists ADD COLUMN position INTEGER",
+    ]
+    for stmt in alter_statements:
+        try:
+            await db.execute(stmt)
+            await db.commit()
+        except Exception:
+            pass
+
 
 async def fetch_one(query: str, params: tuple | list = ()) -> aiosqlite.Row | None:
     """Fetch a single row from the database.

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -5,6 +5,8 @@ CREATE TABLE IF NOT EXISTS users (
   user_id TEXT PRIMARY KEY,
   username TEXT,
   epic_sort_mode TEXT NOT NULL DEFAULT 'added',
+  artist_sort_mode TEXT NOT NULL DEFAULT 'name',
+  wish_sort_mode TEXT NOT NULL DEFAULT 'name',
   created_at TEXT DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -43,6 +45,8 @@ CREATE TABLE IF NOT EXISTS user_wishlist_epics (
   user_id TEXT NOT NULL,
   track_id TEXT NOT NULL,
   note TEXT,
+  added_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  position INTEGER,
   PRIMARY KEY (user_id, track_id),
   FOREIGN KEY (user_id) REFERENCES users(user_id),
   FOREIGN KEY (track_id) REFERENCES tracks(track_id)
@@ -54,6 +58,8 @@ CREATE TABLE IF NOT EXISTS user_fav_artists (
   user_id TEXT NOT NULL,
   artist_id INTEGER NOT NULL,
   badge TEXT CHECK (badge IN ('Bronze','Silver','Gold','Platinum','Diamond','Legendary','VIP','Shiny')),
+  added_at TEXT DEFAULT CURRENT_TIMESTAMP,
+  position INTEGER,
   PRIMARY KEY (user_id, artist_id),
   FOREIGN KEY (user_id) REFERENCES users(user_id),
   FOREIGN KEY (artist_id) REFERENCES artists(artist_id)

--- a/tests/test_username.py
+++ b/tests/test_username.py
@@ -63,7 +63,12 @@ def test_profile_shows_username(monkeypatch):
     cog = ProfileCog(bot)
 
     async def dummy_fetch_one(query, params=()):
-        return {"username": "PlayerX", "epic_sort_mode": "added"}
+        return {
+            "username": "PlayerX",
+            "epic_sort_mode": "added",
+            "artist_sort_mode": "name",
+            "wish_sort_mode": "name",
+        }
 
     async def dummy_fetch_all(query, params=()):
         return []


### PR DESCRIPTION
## Summary
- add artist and wishlist sorting with manual ordering
- replace legacy move command with a unified `/sort`
- extend database schema for new sort modes and positions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898993548e8832bad6d352f90f170f6