### PR TITLE
feat: allow badge selection when adding artist

### DIFF
--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -7,6 +7,7 @@ import asyncio
 import pytest
 import discord
 from discord.ext import commands
+from discord import app_commands
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 os.environ.setdefault("DISCORD_TOKEN", "test-token")
@@ -142,4 +143,48 @@ def test_addwish_inserts_song(monkeypatch):
 
     assert dummy_execute.called
     assert interaction.response.message == "✅ Added to wishlist."
+    asyncio.run(bot.close())
+
+
+def test_addartist_sets_badge(monkeypatch):
+    intents = discord.Intents.none()
+    bot = commands.Bot(command_prefix="!", intents=intents)
+    cog = ProfileCog(bot)
+
+    async def dummy_get_canonical_artist(artist):
+        return {"name": "Artist"}
+
+    async def dummy_fetch_one(query, params):
+        if "SELECT artist_id" in query:
+            return {"artist_id": 1}
+        return None
+
+    async def dummy_execute(query, params):
+        if "user_fav_artists" in query:
+            dummy_execute.called = True
+            dummy_execute.query = query
+            dummy_execute.params = params
+
+    dummy_execute.called = False
+
+    async def dummy_get_next_artist_position(self, uid):
+        return 1
+
+    async def dummy_ensure_user(self, uid):
+        pass
+
+    monkeypatch.setattr(spotify, "get_canonical_artist", dummy_get_canonical_artist)
+    monkeypatch.setattr(db, "fetch_one", dummy_fetch_one)
+    monkeypatch.setattr(db, "execute", dummy_execute)
+    monkeypatch.setattr(ProfileCog, "get_next_artist_position", dummy_get_next_artist_position)
+    monkeypatch.setattr(ProfileCog, "ensure_user", dummy_ensure_user)
+
+    interaction = DummyInteraction()
+    badge_choice = app_commands.Choice(name="Gold", value="Gold")
+    asyncio.run(ProfileCog.addartist.callback(cog, interaction, "Artist", badge_choice))
+
+    assert dummy_execute.called
+    assert "badge" in dummy_execute.query
+    assert dummy_execute.params[2] == "Gold"
+    assert "Gold" in interaction.response.message
     asyncio.run(bot.close())


### PR DESCRIPTION
## Summary
- allow specifying a badge during `/addartist` with choices list
- test adding an artist with a badge

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a6f89520832b8c82d37fc361fefc