### PR TITLE
Remove added-order sorting and default to manual

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -66,8 +66,8 @@ async def init_db() -> None:
 
     # Additional columns for sorting and manual ordering
     alter_statements = [
-        "ALTER TABLE users ADD COLUMN artist_sort_mode TEXT NOT NULL DEFAULT 'name'",
-        "ALTER TABLE users ADD COLUMN wish_sort_mode TEXT NOT NULL DEFAULT 'name'",
+        "ALTER TABLE users ADD COLUMN artist_sort_mode TEXT NOT NULL DEFAULT 'manual'",
+        "ALTER TABLE users ADD COLUMN wish_sort_mode TEXT NOT NULL DEFAULT 'manual'",
         "ALTER TABLE user_wishlist_epics ADD COLUMN added_at TEXT DEFAULT CURRENT_TIMESTAMP",
         "ALTER TABLE user_wishlist_epics ADD COLUMN position INTEGER",
         "ALTER TABLE user_fav_artists ADD COLUMN added_at TEXT DEFAULT CURRENT_TIMESTAMP",

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -4,9 +4,9 @@
 CREATE TABLE IF NOT EXISTS users (
   user_id TEXT PRIMARY KEY,
   username TEXT,
-  epic_sort_mode TEXT NOT NULL DEFAULT 'added',
-  artist_sort_mode TEXT NOT NULL DEFAULT 'name',
-  wish_sort_mode TEXT NOT NULL DEFAULT 'name',
+  epic_sort_mode TEXT NOT NULL DEFAULT 'manual',
+  artist_sort_mode TEXT NOT NULL DEFAULT 'manual',
+  wish_sort_mode TEXT NOT NULL DEFAULT 'manual',
   created_at TEXT DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -198,9 +198,9 @@ def test_profile_shows_badge_with_emoji(monkeypatch):
     async def dummy_fetch_one(query, params=()):
         return {
             "username": "PlayerX",
-            "epic_sort_mode": "added",
+            "epic_sort_mode": "manual",
             "artist_sort_mode": "name",
-            "wish_sort_mode": "name",
+            "wish_sort_mode": "manual",
         }
 
     async def dummy_fetch_all(query, params=()):

--- a/tests/test_username.py
+++ b/tests/test_username.py
@@ -65,9 +65,9 @@ def test_profile_shows_username(monkeypatch):
     async def dummy_fetch_one(query, params=()):
         return {
             "username": "PlayerX",
-            "epic_sort_mode": "added",
-            "artist_sort_mode": "name",
-            "wish_sort_mode": "name",
+            "epic_sort_mode": "manual",
+            "artist_sort_mode": "manual",
+            "wish_sort_mode": "manual",
         }
 
     async def dummy_fetch_all(query, params=()):


### PR DESCRIPTION
## Summary
- Drop "added order" sorting option from artist, epic and wish commands
- Default sorting modes to manual and insert new entries at the top
- Update migrations and tests for manual defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898b999fc38832bb113f237be03738b