### PR TITLE
Ensure profile lists use insertion order

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -56,29 +56,7 @@ async def init_db() -> None:
     # executescript automatically wraps statements in a single transaction
     await db.executescript(sql)
     await db.commit()
-    # Ensure the new username column exists for the users table
-    try:
-        await db.execute("ALTER TABLE users ADD COLUMN username TEXT")
-        await db.commit()
-    except Exception:
-        # Column already exists or cannot be added; ignore
-        pass
-
-    # Additional columns for sorting and manual ordering
-    alter_statements = [
-        "ALTER TABLE users ADD COLUMN artist_sort_mode TEXT NOT NULL DEFAULT 'manual'",
-        "ALTER TABLE users ADD COLUMN wish_sort_mode TEXT NOT NULL DEFAULT 'manual'",
-        "ALTER TABLE user_wishlist_epics ADD COLUMN added_at TEXT DEFAULT CURRENT_TIMESTAMP",
-        "ALTER TABLE user_wishlist_epics ADD COLUMN position INTEGER",
-        "ALTER TABLE user_fav_artists ADD COLUMN added_at TEXT DEFAULT CURRENT_TIMESTAMP",
-        "ALTER TABLE user_fav_artists ADD COLUMN position INTEGER",
-    ]
-    for stmt in alter_statements:
-        try:
-            await db.execute(stmt)
-            await db.commit()
-        except Exception:
-            pass
+    # Schema is defined fully in the migration; no additional columns needed here.
 
 
 async def fetch_one(query: str, params: tuple | list = ()) -> aiosqlite.Row | None:

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -4,9 +4,6 @@
 CREATE TABLE IF NOT EXISTS users (
   user_id TEXT PRIMARY KEY,
   username TEXT,
-  epic_sort_mode TEXT NOT NULL DEFAULT 'manual',
-  artist_sort_mode TEXT NOT NULL DEFAULT 'manual',
-  wish_sort_mode TEXT NOT NULL DEFAULT 'manual',
   created_at TEXT DEFAULT CURRENT_TIMESTAMP
 );
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -196,12 +196,7 @@ def test_profile_shows_badge_with_emoji(monkeypatch):
     cog = ProfileCog(bot)
 
     async def dummy_fetch_one(query, params=()):
-        return {
-            "username": "PlayerX",
-            "epic_sort_mode": "manual",
-            "artist_sort_mode": "name",
-            "wish_sort_mode": "manual",
-        }
+        return {"username": "PlayerX"}
 
     async def dummy_fetch_all(query, params=()):
         if "user_fav_artists" in query:

--- a/tests/test_username.py
+++ b/tests/test_username.py
@@ -63,12 +63,7 @@ def test_profile_shows_username(monkeypatch):
     cog = ProfileCog(bot)
 
     async def dummy_fetch_one(query, params=()):
-        return {
-            "username": "PlayerX",
-            "epic_sort_mode": "manual",
-            "artist_sort_mode": "manual",
-            "wish_sort_mode": "manual",
-        }
+        return {"username": "PlayerX"}
 
     async def dummy_fetch_all(query, params=()):
         return []


### PR DESCRIPTION
## Summary
- remove sort mode columns and legacy alphabetical sorting
- fetch epics, wishlist items, and favourite artists strictly by insertion order
- simplify artist autocomplete to follow manual ordering

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898c43567cc832ba0d333cec3ccb85d