### PR TITLE
Restrict epics to one per song and simplify deletion

### DIFF
--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -572,13 +572,13 @@ class ProfileCog(commands.Cog):
         )
         exists = await db.fetch_one(
             """
-            SELECT 1 FROM user_epics WHERE user_id=? AND track_id=? AND epic_number=?
+            SELECT 1 FROM user_epics WHERE user_id=? AND track_id=?
             """,
-            (user_id, t["track_id"], epic_number),
+            (user_id, t["track_id"]),
         )
         if exists:
             await interaction.response.send_message(
-                "You already own this Epic.", ephemeral=True
+                "You already own an Epic for this song.", ephemeral=True
             )
             return
         next_pos = await self.get_next_position(user_id)
@@ -596,15 +596,15 @@ class ProfileCog(commands.Cog):
 
     # Command: remove an Epic
     @app_commands.command(name="delepic", description="Remove an Epic from your collection")
-    @app_commands.rename(track="song", epic_number="number")
-    @app_commands.describe(track="The song (selectable via autocomplete)", epic_number="The serial number of the Epic")
+    @app_commands.rename(track="song")
+    @app_commands.describe(track="The song (selectable via autocomplete)")
     @app_commands.autocomplete(track=autocomplete_tracks)
-    async def delepic(self, interaction: discord.Interaction, track: str, epic_number: int) -> None:
+    async def delepic(self, interaction: discord.Interaction, track: str) -> None:
         user_id = str(interaction.user.id)
         # Check if the epic exists
         row = await db.fetch_one(
-            "SELECT position FROM user_epics WHERE user_id=? AND track_id=? AND epic_number=?",
-            (user_id, track, epic_number),
+            "SELECT position FROM user_epics WHERE user_id=? AND track_id=?",
+            (user_id, track),
         )
         if not row:
             await interaction.response.send_message(
@@ -616,8 +616,8 @@ class ProfileCog(commands.Cog):
         # Remove epic and shift positions
         async with db.transaction():
             await db.execute(
-                "DELETE FROM user_epics WHERE user_id=? AND track_id=? AND epic_number=?",
-                (user_id, track, epic_number),
+                "DELETE FROM user_epics WHERE user_id=? AND track_id=?",
+                (user_id, track),
             )
             # Decrement positions greater than removed
             await db.execute(

--- a/migrations/001_init.sql
+++ b/migrations/001_init.sql
@@ -21,17 +21,16 @@ CREATE TABLE IF NOT EXISTS tracks (
   url TEXT NOT NULL
 );
 
--- Epics table: stores each Epic owned by a user. Epics are identified by a Spotify track
--- and a serial number. The added_at timestamp captures the time of insertion and
--- position can be used for manual ordering. A composite primary key prevents
--- duplicate entries for the same Epic.
+-- Epics table: stores each Epic owned by a user. Each user can own at most one Epic
+-- per track. The added_at timestamp captures the time of insertion and position can
+-- be used for manual ordering.
 CREATE TABLE IF NOT EXISTS user_epics (
   user_id TEXT NOT NULL,
   track_id TEXT NOT NULL,
   epic_number INTEGER NOT NULL CHECK (epic_number > 0),
   added_at TEXT DEFAULT CURRENT_TIMESTAMP,
   position INTEGER,
-  PRIMARY KEY (user_id, track_id, epic_number),
+  PRIMARY KEY (user_id, track_id),
   FOREIGN KEY (user_id) REFERENCES users(user_id),
   FOREIGN KEY (track_id) REFERENCES tracks(track_id)
 );


### PR DESCRIPTION
## Summary
- Prevent users from owning multiple epics of the same song
- Drop epic number argument from `/delepic` command
- Update tests and schema for new epic rules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898f841d4a0832ba7f589c846f8ba1a