### PR TITLE
Ensure all bot responses are ephemeral

### DIFF
--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -250,7 +250,7 @@ class ProfileCog(commands.Cog):
                 await interaction.response.send_message(content, view=view, ephemeral=True)
         except Exception:
             if hasattr(interaction, "response") and hasattr(interaction.response, "send_message"):
-                await interaction.response.send_message(content, view=view)
+                await interaction.response.send_message(content, view=view, ephemeral=True)
 
     # Helper method to ensure a user row exists
     async def ensure_user(self, user_id: str) -> None:
@@ -1112,7 +1112,7 @@ class ProfileCog(commands.Cog):
         else:
             embed.add_field(name="🎯 Wishlist", value="No wishes", inline=False)
 
-        await interaction.response.send_message(embed=embed, ephemeral=(user is None))
+        await interaction.response.send_message(embed=embed, ephemeral=True)
 
     # Command: wishcurrent (current song as wishlist)
     @app_commands.command(name="wishcurrent", description="Add the currently playing song (Spotify) to your wishlist")

--- a/cogs/search.py
+++ b/cogs/search.py
@@ -133,7 +133,7 @@ class SearchCog(commands.Cog):
                 value="No one is looking for this Epic.",
                 inline=False,
             )
-        await interaction.response.send_message(embed=embed)
+        await interaction.response.send_message(embed=embed, ephemeral=True)
 
     # /tradehelp command
     @app_commands.command(
@@ -196,7 +196,7 @@ class SearchCog(commands.Cog):
             embed.add_field(name="They want what you have", value="\n".join(lines) + more, inline=False)
         else:
             embed.add_field(name="They want what you have", value="No matches", inline=False)
-        await interaction.response.send_message(embed=embed, ephemeral=(user is not None and user.id != interaction.user.id))
+        await interaction.response.send_message(embed=embed, ephemeral=True)
 
     # /findcollector command
     @app_commands.command(
@@ -257,4 +257,4 @@ class SearchCog(commands.Cog):
             value="\n".join(lines) + more,
             inline=False,
         )
-        await interaction.response.send_message(embed=embed)
+        await interaction.response.send_message(embed=embed, ephemeral=True)

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -48,6 +48,7 @@ def test_addepic_rejects_non_positive_number(monkeypatch):
     interaction = DummyInteraction()
     asyncio.run(ProfileCog.addepic.callback(cog, interaction, "abc", 0))
     assert interaction.response.message == "Epic number must be > 0."
+    assert interaction.response.kwargs.get("ephemeral") is True
     asyncio.run(bot.close())
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -42,6 +42,7 @@ def test_findcollector_artist_not_found(monkeypatch):
     asyncio.run(SearchCog.findcollector.callback(cog, interaction, "abc"))
 
     assert interaction.response.message == "Artist not found."
+    assert interaction.response.kwargs.get("ephemeral") is True
     asyncio.run(bot.close())
 
 
@@ -65,6 +66,7 @@ def test_findcollector_no_collectors(monkeypatch):
     asyncio.run(SearchCog.findcollector.callback(cog, interaction, "Artist"))
 
     assert interaction.response.message == "Nobody has set this artist as a favorite."
+    assert interaction.response.kwargs.get("ephemeral") is True
     asyncio.run(bot.close())
 
 
@@ -98,4 +100,5 @@ def test_findcollector_lists_collectors(monkeypatch):
     assert "Gold" in lines[1]
     assert lines[2].startswith("<@1>")
     assert "Bronze" in lines[2]
+    assert interaction.response.kwargs.get("ephemeral") is True
     asyncio.run(bot.close())

--- a/tests/test_username.py
+++ b/tests/test_username.py
@@ -54,6 +54,7 @@ def test_username_command_updates_db(monkeypatch):
 
     assert executed["params"] == ("Player1", "1")
     assert "Username set" in interaction.response.message
+    assert interaction.response.kwargs.get("ephemeral") is True
     asyncio.run(bot.close())
 
 
@@ -80,5 +81,6 @@ def test_profile_shows_username(monkeypatch):
     embed = interaction.response.kwargs["embed"]
     assert embed.fields[0].name == "👤 SM-Username"
     assert embed.fields[0].value == "PlayerX"
+    assert interaction.response.kwargs.get("ephemeral") is True
     asyncio.run(bot.close())
 


### PR DESCRIPTION
## Summary
- Force every slash command response to include `ephemeral=True`
- Add tests verifying ephemeral responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898ffc66e94832bafc5459f1710bd13