### PR TITLE
feat: group slash commands in /commands

### DIFF
--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -40,6 +40,7 @@ def test_commands_lists_registered_commands():
     interaction = DummyInteraction(bot_module.bot)
     asyncio.run(bot_module.list_commands.callback(interaction))
 
+    assert "**Other**" in interaction.response.message
     assert "/dummy - Dummy command" in interaction.response.message
     assert interaction.response.kwargs.get("ephemeral") is True
 


### PR DESCRIPTION
## Summary
- group /commands output into General, Profile, Collection Management, Sorting, and Search & Trading sections
- include fallback **Other** section for unclassified commands
- adjust test to expect grouped command list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68990d853934832b9d50d2ecc1fb315d