### PR TITLE
Include searchuser in command list

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -91,7 +91,7 @@ async def list_commands(interaction: discord.Interaction) -> None:
             "favartistcurrent",
         ],
         "Sorting": ["sortepics", "sortwishes", "sortartists"],
-        "Search & Trading": ["findowners", "findcollector", "tradehelp"],
+        "Search & Trading": ["findcollector", "findowners", "searchuser", "tradehelp"],
     }
 
     lines: list[str] = []
@@ -105,7 +105,7 @@ async def list_commands(interaction: discord.Interaction) -> None:
                 used.add(name)
         if entries:
             lines.append(f"**{title}**")
-            lines.extend(entries)
+            lines.extend(sorted(entries))
             lines.append("")
 
     leftovers = [c for n, c in tree_cmds.items() if n not in used]


### PR DESCRIPTION
## Summary
- add `searchuser` to `/commands` output and sort command entries
- test `/commands` with `searchuser`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899935784c0832bb32b8c5731fd2702