### PR TITLE
fix: improve /commands sorting

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -97,7 +97,7 @@ async def list_commands(interaction: discord.Interaction) -> None:
             "favartistcurrent",
         ],
         "Sorting": ["sortepics", "sortwishes", "sortartists"],
-        "Search & Trading": ["findcollector", "findowners", "searchuser", "tradehelp"],
+        "Search & Trading": ["searchuser", "findcollector", "findowners", "tradehelp"],
     }
 
     lines: list[str] = []
@@ -111,7 +111,7 @@ async def list_commands(interaction: discord.Interaction) -> None:
                 used.add(name)
         if entries:
             lines.append(f"**{title}**")
-            lines.extend(sorted(entries))
+            lines.extend(entries)
             lines.append("")
 
     leftovers = [c for n, c in tree_cmds.items() if n not in used]


### PR DESCRIPTION
## Summary
- keep command pairs grouped and manual order in `/commands`
- reorganize Search & Trading section

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899a6f4747c832b8c00867e9315c025